### PR TITLE
Add .yardopts to enable README to be autouploaded to rubydocs.info

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--readme README.md


### PR DESCRIPTION
The generated documentation file doesn't include the README by default, even though running `yard` locally does. I'm hoping this will force the hook to generate it and add to the site.