### PR TITLE
Ensure collector state is reset in the face of errors on event recording

### DIFF
--- a/test/lib/conrad/collector_test.rb
+++ b/test/lib/conrad/collector_test.rb
@@ -3,6 +3,22 @@ require 'test_helper'
 class CollectorTest < Minitest::Test
   PASS_THROUGH = ->(event) { event }
 
+  class ArbitraryTestingError < StandardError; end
+
+  class MockLogger
+    attr_reader :logs
+
+    def initialize
+      @logs = []
+    end
+
+    %i[debug info warn error fatal].each do |level|
+      define_method(level) do |msg|
+        @logs << { level => msg }
+      end
+    end
+  end
+
   class ProcessorDropsEven
     def initialize
       @times = 0
@@ -14,6 +30,23 @@ class CollectorTest < Minitest::Test
       throw :halt_conrad_processing if @times.even?
 
       event
+    end
+  end
+
+  class EmitterDropsOdd
+    attr_reader :events
+
+    def initialize
+      @times = 0
+      @events = []
+    end
+
+    def call(event)
+      @times += 1
+
+      raise ArbitraryTestingError, 'Arbitrary odd number' if @times.odd?
+
+      @events << event.clone
     end
   end
 
@@ -50,7 +83,7 @@ class CollectorTest < Minitest::Test
   end
 
   def test_does_not_just_emit_events_added
-    Conrad::Collector.current.emitter = ->(_event) { raise 'Should not emit event' }
+    Conrad::Collector.current.emitter = ->(_event) { flunk 'Should not emit event' }
 
     Conrad::Collector.current.add_event(foo: 'bar')
     Conrad::Collector.current.add_event(fizz: 'bazz')
@@ -60,7 +93,7 @@ class CollectorTest < Minitest::Test
 
   def test_does_not_add_events_when_halt_conrad_processing_is_thrown
     Conrad::Collector.current.processors = [ProcessorDropsEven.new]
-    Conrad::Collector.current.emitter = ->(_event) { raise 'Should not emit event' }
+    Conrad::Collector.current.emitter = ->(_event) { flunk 'Should not emit event' }
 
     Conrad::Collector.current.add_event(will_be: 'there')
     Conrad::Collector.current.add_event(is_not: 'there')
@@ -103,7 +136,7 @@ class CollectorTest < Minitest::Test
 
     Conrad::Collector.current.formatter = PASS_THROUGH
     Conrad::Collector.current.emitter = emitter
-    Conrad::Collector.current.event_metadata = { meta: 'totally' }
+    Conrad::Collector.current.add_metadata(meta: 'totally')
 
     Conrad::Collector.current.add_event(foo: 'bar')
     Conrad::Collector.current.add_event(boom: 'shaka')
@@ -116,10 +149,10 @@ class CollectorTest < Minitest::Test
 
     Conrad::Collector.default_formatter = PASS_THROUGH
     Conrad::Collector.default_emitter = emitter
-    Conrad::Collector.current.event_metadata = { meta: 'totally' }
+    Conrad::Collector.current.add_metadata(meta: 'totally')
 
     other_thread = Thread.new do
-      Conrad::Collector.current.event_metadata = { separate_thread: true }
+      Conrad::Collector.current.add_metadata(separate_thread: true)
       Conrad::Collector.current.add_event(other_thread: 'multithread')
       Conrad::Collector.current.events
     end
@@ -134,7 +167,7 @@ class CollectorTest < Minitest::Test
 
   def test_clears_events_and_metadata_after_sending_events
     Conrad::Collector.current.emitter = PASS_THROUGH
-    Conrad::Collector.current.event_metadata = { whatever: 'who cares' }
+    Conrad::Collector.current.add_metadata(whatever: 'who cares')
 
     Conrad::Collector.current.add_event(foo: 'bar')
     Conrad::Collector.current.record_events
@@ -192,5 +225,51 @@ class CollectorTest < Minitest::Test
     assert_raises(Conrad::ForbiddenKey, 'Invalid hash key') do
       Conrad::Collector.current.add_event({} => 'failure')
     end
+  end
+
+  def test_errors_on_recording_events_still_resets_event_data
+    emitter = ->(_events) { raise ArbitraryTestingError, 'Something went wrong' }
+
+    # Set `emit_as_batch` to true so that errors still bubble up.
+    collector = Conrad::Collector.new(emitter: emitter, emit_as_batch: true)
+
+    collector.add_metadata(foo: 'bar')
+    collector.add_event(this: 'works')
+    collector.record_events
+
+    flunk 'An error should have been raised by #record events, the assert is in the rescue'
+  rescue ArbitraryTestingError
+    assert_equal({}, collector.event_metadata)
+  end
+
+  def test_an_error_raised_for_individual_event_emitting_does_not_prevent_future_events
+    emitter = EmitterDropsOdd.new
+
+    collector = Conrad::Collector.new(emitter: emitter, formatter: PASS_THROUGH)
+
+    collector.add_event(one: 'one')
+    collector.add_event(two: 'two')
+
+    collector.record_events
+
+    assert_equal [{ two: 'two' }], emitter.events
+  end
+
+  def test_errors_raised_for_individual_emitted_events_are_logged
+    emitter = EmitterDropsOdd.new
+    logger = MockLogger.new
+
+    collector = Conrad::Collector.new(emitter: emitter, logger: logger)
+
+    collector.add_event(one: 'one')
+    collector.add_event(two: 'two')
+    collector.record_events
+
+    assert_equal 1, logger.logs.length
+
+    logged_error = logger.logs.first
+
+    assert_instance_of ArbitraryTestingError, logged_error[:error]
+    assert_equal 'Arbitrary odd number', logged_error[:error].message
   end
 end


### PR DESCRIPTION
This PR also adds some logging since we're now rescuing on individual emitted event errors. We need some way to track that, and for now this will work. Eventually we could return the result of each emitted thing and an error raised if that happened, but this should be enough for now.