### PR TITLE
Require AWS SDK v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Conrad Changelog
 
 ## Unreleased
+* Require AWS SDK v3. [#34](https://github.com/getoutreach/conrad/pull/34)
+
+## Version 2.4.1
 * Adding default `require 'aws-sdk'` to AWS emitters. [#33](https://github.com/getoutreach/conrad/pull/33)
 
-## Version 2.5.0
-* Adding support for multiple emitters per collector [#28](https://github.com/getoutreach/conrad/pull/28)
-
 ## Version 2.4.0
+* Adding support for multiple emitters per collector [#28](https://github.com/getoutreach/conrad/pull/28)
 * Adding the ability to emit events in a background thread [#28](https://github.com/getoutreach/conrad/pull/28)
 * Adding a Kinesis Emitter [#30](https://github.com/getoutreach/conrad/pull/30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Require AWS SDK v3. [#34](https://github.com/getoutreach/conrad/pull/34)
+* Fix `warning: instance variable @default_X not initialized`. [#34](https://github.com/getoutreach/conrad/pull/34)
 
 ## Version 2.4.1
 * Adding default `require 'aws-sdk'` to AWS emitters. [#33](https://github.com/getoutreach/conrad/pull/33)

--- a/conrad.gemspec
+++ b/conrad.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-stub-const'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 13.0'
   spec.add_development_dependency 'rubocop', '~> 0.60.0'
 end

--- a/conrad.gemspec
+++ b/conrad.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activemodel'
-  spec.add_dependency 'aws-sdk'
+  spec.add_dependency 'aws-sdk-kinesis'
+  spec.add_dependency 'aws-sdk-sqs'
 
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-stub-const'

--- a/lib/conrad/collector.rb
+++ b/lib/conrad/collector.rb
@@ -49,17 +49,17 @@ module Conrad
 
       # @return the configured formatter. Defaults to Conrad::Formatters::Json
       def default_formatter
-        @default_formatter || Conrad::Formatters::JSON.new
+        @default_formatter ||= Conrad::Formatters::JSON.new
       end
 
       # @return the configured emitter. Defaults to Conrad::Emitters::Stdout
       def default_emitter
-        @default_emitter || Conrad::Emitters::Stdout.new
+        @default_emitter ||= Conrad::Emitters::Stdout.new
       end
 
       # @return [Array<#call>]
       def default_processors
-        @default_processors || []
+        @default_processors ||= []
       end
     end
 

--- a/lib/conrad/emitters/amazon_base.rb
+++ b/lib/conrad/emitters/amazon_base.rb
@@ -1,5 +1,5 @@
 require 'active_model'
-require 'aws-sdk'
+require 'aws-sdk-core'
 
 module Conrad
   module Emitters

--- a/test/lib/conrad/kinesis_test.rb
+++ b/test/lib/conrad/kinesis_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'aws-sdk'
+require 'aws-sdk-kinesis'
 
 class KinesisEmitterTest < Minitest::Test
   class MockAwsCredentialResolver

--- a/test/lib/conrad/sqs_emitter_test.rb
+++ b/test/lib/conrad/sqs_emitter_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'aws-sdk'
+require 'aws-sdk-sqs'
 
 class SqsEmitterTest < Minitest::Test
   class MockAwsCredentialResolver


### PR DESCRIPTION
I am trying to fix the flagship so that it isn't bundling all 222 AWS gems, and it looks like this gem is causing it.

@gaorlov Do you think we can release a new version of this? I'm not quite sure how to push a new version, but I can learn how to do it if you think it's Ok? I'll then create the flagship PR to upgrade this gem. Thanks!
