### PR TITLE
Release v3.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,39 @@ jobs:
       - run:
           name: Run Tests
           command: bundle exec rake test
+  ruby2.6:
+    docker:
+      - image: circleci/ruby:2.6
+    steps:
+      - checkout
+      - run:
+          name: Bundle install
+          command: bundle install
+      - run:
+          name: Rubocop
+          command: bundle exec rubocop --fail-level autocorrect
+      - run:
+          name: Run Tests
+          command: bundle exec rake test
+  ruby2.7:
+    docker:
+      - image: circleci/ruby:2.7
+    steps:
+      - checkout
+      - run:
+          name: Bundle install
+          command: bundle install
+      - run:
+          name: Rubocop
+          command: bundle exec rubocop --fail-level autocorrect
+      - run:
+          name: Run Tests
+          command: bundle exec rake test
 workflows:
   version: 2
   build:
     jobs:
       - ruby2.4
       - ruby2.5
+      - ruby2.6
+      - ruby2.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.4
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Metrics/MethodLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Conrad Changelog
 
 ## Unreleased
+
+## Version 3.0.0
 * Require AWS SDK v3. [#34](https://github.com/getoutreach/conrad/pull/34)
 * Fix `warning: instance variable @default_X not initialized`. [#34](https://github.com/getoutreach/conrad/pull/34)
 

--- a/conrad.gemspec
+++ b/conrad.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-stub-const'
   spec.add_development_dependency 'rake', '>= 13.0'
-  spec.add_development_dependency 'rubocop', '~> 0.60.0'
+  spec.add_development_dependency 'rubocop', '~> 0.82.0'
 end

--- a/lib/conrad/version.rb
+++ b/lib/conrad/version.rb
@@ -1,5 +1,5 @@
 # :nodoc:
 module Conrad
   # :nodoc:
-  VERSION = '2.4.0'.freeze
+  VERSION = '3.0.0'.freeze
 end


### PR DESCRIPTION
- Release v3.0.0.
- Start testing with Ruby 2.6 and 2.7.
