### PR TITLE
[DP-3112]Update deprecated circle image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   ruby2.4:
     docker:
-      - image: circleci/ruby:2.4
+      - image: cimg/ruby:2.4
     steps:
       - checkout
       - run:
@@ -16,7 +16,7 @@ jobs:
           command: bundle exec rake test
   ruby2.5:
     docker:
-      - image: circleci/ruby:2.5
+      - image: cimg/ruby:2.5
     steps:
       - checkout
       - run:
@@ -30,7 +30,7 @@ jobs:
           command: bundle exec rake test
   ruby2.6:
     docker:
-      - image: circleci/ruby:2.6
+      - image: cimg/ruby:2.6
     steps:
       - checkout
       - run:
@@ -44,7 +44,7 @@ jobs:
           command: bundle exec rake test
   ruby2.7:
     docker:
-      - image: circleci/ruby:2.7
+      - image: cimg/ruby:2.7
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,35 +1,5 @@
 version: 2
 jobs:
-  ruby2.4:
-    docker:
-      - image: cimg/ruby:2.4
-    steps:
-      - add_ssh_keys
-      - checkout
-      - run:
-          name: Bundle install
-          command: bundle install
-      - run:
-          name: Rubocop
-          command: bundle exec rubocop --fail-level autocorrect
-      - run:
-          name: Run Tests
-          command: bundle exec rake test
-  ruby2.5:
-    docker:
-      - image: cimg/ruby:2.5
-    steps:
-      - add_ssh_keys
-      - checkout
-      - run:
-          name: Bundle install
-          command: bundle install
-      - run:
-          name: Rubocop
-          command: bundle exec rubocop --fail-level autocorrect
-      - run:
-          name: Run Tests
-          command: bundle exec rake test
   ruby2.6:
     docker:
       - image: cimg/ruby:2.6
@@ -64,10 +34,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - ruby2.4:
-          context: docker-registry
-      - ruby2.5:
-          context: docker-registry
       - ruby2.6:
           context: docker-registry
       - ruby2.7:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     docker:
       - image: cimg/ruby:2.4
     steps:
+      - add_ssh_keys
       - checkout
       - run:
           name: Bundle install
@@ -18,6 +19,7 @@ jobs:
     docker:
       - image: cimg/ruby:2.5
     steps:
+      - add_ssh_keys
       - checkout
       - run:
           name: Bundle install
@@ -32,6 +34,7 @@ jobs:
     docker:
       - image: cimg/ruby:2.6
     steps:
+      - add_ssh_keys
       - checkout
       - run:
           name: Bundle install
@@ -46,6 +49,7 @@ jobs:
     docker:
       - image: cimg/ruby:2.7
     steps:
+      - add_ssh_keys
       - checkout
       - run:
           name: Bundle install
@@ -60,7 +64,11 @@ workflows:
   version: 2
   build:
     jobs:
-      - ruby2.4
-      - ruby2.5
-      - ruby2.6
-      - ruby2.7
+      - ruby2.4:
+          context: docker-registry
+      - ruby2.5:
+          context: docker-registry
+      - ruby2.6:
+          context: docker-registry
+      - ruby2.7:
+          context: docker-registry


### PR DESCRIPTION
Tests faield on 2.4 and 2.5. Since we're using ruby2.6 in flagship, I'll just remove the build for 2.4 and 2.5
